### PR TITLE
Fix for crash when enter key is held down for longer than 3 secs

### DIFF
--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -7,7 +7,7 @@
  * SoundFallback use just the simple Audio tag, works ok but not as feature full as web audio api.
  * 
  *  License: Apache 2.0
- *  author:  Ciar�n McCann
+ *  author:  Ciarán McCann
  *  url: http://www.ciaranmccann.me/
  */
 ///<reference path="../system/Utilies.ts"/>

--- a/src/audio/Sound.ts
+++ b/src/audio/Sound.ts
@@ -7,7 +7,7 @@
  * SoundFallback use just the simple Audio tag, works ok but not as feature full as web audio api.
  * 
  *  License: Apache 2.0
- *  author:  Ciarán McCann
+ *  author:  Ciarï¿½n McCann
  *  url: http://www.ciaranmccann.me/
  */
 ///<reference path="../system/Utilies.ts"/>
@@ -68,9 +68,10 @@ class Sound
 
     pause()
     {
-        if (Settings.SOUND && this.buffer != null)
-        {
-            this.source.noteOff(0);
+        if (Settings.SOUND && this.buffer != null) {
+            if (typeof(this.source.noteOff) !== 'undefined') {
+                this.source.noteOff(0);
+            }
         }
     }
 


### PR DESCRIPTION
If you hold down the enter key for longer than 3 seconds, the game would crash because it references a function that does not exist.

This addresses the issue by checking if the function exists before attempting to call it, as this will allow the code to begin working if this function is implemented in the future as opposed to simply deleting that line of code.
